### PR TITLE
Use operator | and |= for set addition

### DIFF
--- a/include/boost/icl/concept/interval_associator.hpp
+++ b/include/boost/icl/concept/interval_associator.hpp
@@ -474,7 +474,7 @@ template<class Type, class OperandT>
 typename enable_if<is_right_intra_combinable<Type, OperandT>, Type>::type&
 operator |= (Type& object, const OperandT& operand)
 { 
-    return object += operand; 
+    return object |= operand; 
 }
 
 #ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
@@ -489,7 +489,7 @@ template<class Type, class OperandT>
 typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
 operator | (Type object, const OperandT& operand)
 {
-    return object += operand; 
+    return object |= operand; 
 }
 
 #else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
@@ -499,14 +499,14 @@ typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
 operator | (const Type& object, const OperandT& operand)
 {
     Type temp = object;
-    return boost::move(temp += operand); 
+    return boost::move(temp |= operand); 
 }
 
 template<class Type, class OperandT>
 typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
 operator | (Type&& object, const OperandT& operand)
 {
-    return boost::move(object += operand); 
+    return boost::move(object |= operand); 
 }
 
 #endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
@@ -533,14 +533,14 @@ typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
 operator | (const OperandT& operand, const Type& object)
 {
     Type temp = object;
-    return boost::move(temp += operand);
+    return boost::move(temp |= operand);
 }
 
 template<class Type, class OperandT>
 typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
 operator | (const OperandT& operand, Type&& object)
 {
-    return boost::move(object += operand); 
+    return boost::move(object |= operand); 
 }
 
 #endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
@@ -557,7 +557,7 @@ template<class Type>
 typename enable_if<is_interval_container<Type>, Type>::type
 operator | (Type object, const Type& operand)
 {
-    return object += operand; 
+    return object |= operand; 
 }
 #else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
 
@@ -566,28 +566,28 @@ typename enable_if<is_interval_container<Type>, Type>::type
 operator | (const Type& object, const Type& operand)
 {
     Type temp = object;
-    return boost::move(temp += operand); 
+    return boost::move(temp |= operand); 
 }
 
 template<class Type>
 typename enable_if<is_interval_container<Type>, Type>::type
 operator | (Type&& object, const Type& operand)
 {
-    return boost::move(object += operand); 
+    return boost::move(object |= operand); 
 }
 
 template<class Type>
 typename enable_if<is_interval_container<Type>, Type>::type
 operator | (const Type& operand, Type&& object)
 {
-    return boost::move(object += operand); 
+    return boost::move(object |= operand); 
 }
 
 template<class Type>
 typename enable_if<is_interval_container<Type>, Type>::type
 operator | (Type&& object, Type&& operand)
 {
-    return boost::move(object += operand); 
+    return boost::move(object |= operand); 
 }
 
 #endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES


### PR DESCRIPTION
As mentioned in the document (http://www.boost.org/doc/libs/1_56_0/libs/icl/doc/html/boost_icl/function_reference/addition.html), a set union semantics is often attached operators |= and |. This is the case, for example, when using boost::dynamic_bitset, which does not provide operators += and + for set union semantics. 

However, the original implementation of operators |= and | still uses += and + for the underlying set container. This makes operators |= and | less useful. Furthermore, we can't use boost::dynamic_bitset for icl objects currently. I think this is an unnecessary limitation.

A proper fix would be changing += and + into |= and | when users call the |= and | operators. The code will be more consistent with the statement above.
