### PR TITLE
Add an "inplace_assign" functor to boost::icl::interval_map

### DIFF
--- a/doc/concepts.qbk
+++ b/doc/concepts.qbk
@@ -208,11 +208,12 @@ For `Combine` functors, the Icl provides an __inverse__ functor.
 [[__ip_star__`<T>`]    [__ip_slash__`<T>`]    ]
 [[__ip_max__`<T>`]     [__ip_min__`<T>`]    ]
 [[__ip_identity__`<T>`][__ip_erasure__`<T>`]]
+[[__ip_assign__`<T>`]  [`no inverse`]]
 [[`Functor`]           [__ip_erasure__`<T>`]]
 ]
 
 The meta function __inverse__ is mutually implemented for
-all but the default functor `Functor`
+all but the default functor `Functor` and the assign functor
 such that e.g.
 `inverse<inplace_minus<T> >::type` yields `inplace_plus<T>`.
 Not in every case, e.g. `max/min`, does the __inverse__ functor

--- a/doc/icl.qbk
+++ b/doc/icl.qbk
@@ -92,6 +92,7 @@ Distributed under the Boost Software License, Version 1.0.
 [def __ip_caret__     [classref boost::icl::inplace_caret    inplace_caret]]
 [def __ip_min__       [classref boost::icl::inplace_min      inplace_min]]
 [def __ip_max__       [classref boost::icl::inplace_max      inplace_max]]
+[def __ip_assign__    [classref boost::icl::inplace_assign   inplace_assign]]
 [def __ip_identity__  [classref boost::icl::inplace_identity inplace_identity]]
 [def __ip_erasure__   [classref boost::icl::inplace_erasure  inplace_erasure]]
 [def __ip_bitset_union__      [classref boost::icl::inplace_bitset_union      inplace_bitset_union]]

--- a/include/boost/icl/functors.hpp
+++ b/include/boost/icl/functors.hpp
@@ -252,6 +252,22 @@ namespace boost{namespace icl
     template<>
     inline std::string unary_template_to_string<inplace_min>::apply() { return "min="; }
 
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_assign
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_assign<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        {
+            object = operand;
+        }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_assign>::apply() { return "="; }
+
     //--------------------------------------------------------------------------
     // Inter_section functor
     //--------------------------------------------------------------------------


### PR DESCRIPTION
When adding to the container, the functor simply overwrites all hitherto values in the adding interval.
