### PR TITLE
Allow construction from ranges of intervals

### DIFF
--- a/include/boost/icl/interval_map.hpp
+++ b/include/boost/icl/interval_map.hpp
@@ -92,6 +92,15 @@ public:
     explicit interval_map(const value_type& value_pair): base_type()
     { this->add(value_pair); }
 
+    /// Constructor for a range of intervals
+    template <typename InputIterator>
+    interval_map(InputIterator first, const InputIterator last)
+    {
+      for (; first != last; ++first)
+      {
+        this->add(*first);
+      }
+    }
 
     /// Assignment from a base interval_map.
     template<class SubType>

--- a/include/boost/icl/interval_set.hpp
+++ b/include/boost/icl/interval_set.hpp
@@ -115,6 +115,16 @@ public:
         this->add(itv); 
     }
 
+    /// Constructor for a range of intervals
+    template <typename InputIterator>
+    interval_set(InputIterator first, const InputIterator last)
+    {
+      for (; first != last; ++first)
+      {
+        this->add(*first);
+      }
+    }
+
     /// Assignment from a base interval_set.
     template<class SubType>
     void assign(const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)


### PR DESCRIPTION
This allows constructing interval_map and interval_set as const
variables without having to resort to constructor functions. E.g.
boost::assign::list_of can now be used to fill them.
