### PR TITLE
Fix compiler error when building with FASTBuild

### DIFF
--- a/include/boost/icl/detail/element_iterator.hpp
+++ b/include/boost/icl/detail/element_iterator.hpp
@@ -89,7 +89,7 @@ struct elemental;
 
     template< class DomainT, class CodomainT, 
               ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval >
-    struct elemental<std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare)const, CodomainT> >
+    struct elemental<std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare) const, CodomainT> >
     {
         typedef std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare), CodomainT> segment_type;
         typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare)                       interval_type;
@@ -113,7 +113,7 @@ struct elemental;
     };
 
     template< class CodomainT, ICL_INTERVAL(ICL_COMPARE) Interval >
-    struct elemental<std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare)const, CodomainT> >
+    struct elemental<std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare) const, CodomainT> >
     {
         typedef std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare), CodomainT> segment_type;
         typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare)                       interval_type;
@@ -161,7 +161,7 @@ struct segment_adapter<SegmentIteratorT, ICL_INTERVAL_TYPE(Interval,DomainT,Comp
 
 template < class SegmentIteratorT, class DomainT, class CodomainT, 
            ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval >
-struct segment_adapter<SegmentIteratorT, std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare)const, CodomainT> >
+struct segment_adapter<SegmentIteratorT, std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare) const, CodomainT> >
 {
     typedef segment_adapter                         type;
     typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare)               interval_type;
@@ -214,7 +214,7 @@ struct segment_adapter
 };
 
 template < class SegmentIteratorT, class CodomainT, ICL_INTERVAL(ICL_COMPARE) Interval >
-struct segment_adapter<SegmentIteratorT, std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare)const, CodomainT> >
+struct segment_adapter<SegmentIteratorT, std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare) const, CodomainT> >
 {
     typedef segment_adapter                                type;
     typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare)    interval_type;


### PR DESCRIPTION
FASTBuild attempts to preprocess and cache `element_iterator.hpp`, but the missing space between the `)` and the `const` tokens cause the compiler to throw error [C2065][1]: `'Intervalconst': undeclared identifier`


[1]: https://msdn.microsoft.com/en-us/library/ewcf0002.aspx