### PR TITLE
Fix invalid insertion hint to underlying set container

### DIFF
--- a/include/boost/icl/interval_base_set.hpp
+++ b/include/boost/icl/interval_base_set.hpp
@@ -437,7 +437,7 @@ inline void interval_base_set<SubType,DomainT,Compare,Interval,Alloc>
     if(!icl::is_empty(lead_gap))
         //           [lead_gap--- . . .
         // [prior_)           [-- it_ ...
-        this->_set.insert(prior(it_), lead_gap);
+        this->_set.insert(cyclic_prior(*this, it_), lead_gap);
 
     // . . . --------- . . . addend interval
     //      [-- it_ --)      has a common part with the first overval


### PR DESCRIPTION
The code in the add_segment function tries to get the prior of an
iterator that may be the first iterator of the underlying set container.
This is then used as an insertion hint which causes a segfault in some
standard container libraries.

The fix is to use cyclic_prior instead.

This is a fix for ticket #12872.