### PR TITLE
Fix runtime error

### DIFF
--- a/include/boost/icl/interval_bounds.hpp
+++ b/include/boost/icl/interval_bounds.hpp
@@ -41,8 +41,8 @@ public:
     interval_bounds all  ()const { return interval_bounds(_bits & _all  ); }
     interval_bounds left ()const { return interval_bounds(_bits & _left ); }
     interval_bounds right()const { return interval_bounds(_bits & _right); }
-    interval_bounds reverse_left ()const { return interval_bounds((~_bits>>1) & _right); }
-    interval_bounds reverse_right()const { return interval_bounds((~_bits<<1) & _left ); }
+    interval_bounds reverse_left ()const { return interval_bounds((((bound_type)~_bits)>>1) & _right); }
+    interval_bounds reverse_right()const { return interval_bounds((((bound_type)~_bits)<<1) & _left ); }
 
     bound_type bits()const{ return _bits; }
 
@@ -77,4 +77,3 @@ private:
 }} // namespace icl boost
 
 #endif
-


### PR DESCRIPTION
This fixes undefined behavior, which is reported when compiled with -fsanitize=undefined.

The ~ operator results in an integer promotion of _bits, with the result being negative. The following shift results in undefined behavior. Casting to bound_type solves this issue.

I *think* I successfully ran all unit tests. The jamfile automatically executes them, right?