### PR TITLE
Inheriting std::iterator is deprecated in C++17

### DIFF
--- a/include/boost/icl/iterator.hpp
+++ b/include/boost/icl/iterator.hpp
@@ -16,12 +16,15 @@ namespace boost{namespace icl
 
 /** \brief Performes an addition using a container's memberfunction add, when operator= is called. */
 template<class ContainerT> class add_iterator
-    : public std::iterator<std::output_iterator_tag, void, void, void, void>
 {
 public:
     /// The container's type.
     typedef ContainerT container_type;
     typedef std::output_iterator_tag iterator_category; 
+    typedef void value_type;
+    typedef void difference_type;
+    typedef void pointer;
+    typedef void reference;
 
     /** An add_iterator is constructed with a container and a position 
         that has to be maintained. */
@@ -57,12 +60,15 @@ inline add_iterator<ContainerT> adder(ContainerT& cont, IteratorT iter_)
 
 /** \brief Performes an insertion using a container's memberfunction add, when operator= is called. */
 template<class ContainerT> class insert_iterator
-    : public std::iterator<std::output_iterator_tag, void, void, void, void>
 {
 public:
     /// The container's type.
     typedef ContainerT container_type;
     typedef std::output_iterator_tag iterator_category; 
+    typedef void value_type;
+    typedef void difference_type;
+    typedef void pointer;
+    typedef void reference;
 
     /** An insert_iterator is constructed with a container and a position 
         that has to be maintained. */


### PR DESCRIPTION
Therefore replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>