### PR TITLE
Add missing header to right_open_interval.hpp

### DIFF
--- a/include/boost/icl/right_open_interval.hpp
+++ b/include/boost/icl/right_open_interval.hpp
@@ -11,6 +11,7 @@ Copyright (c) 2010-2010: Joachim Faulhaber
 #include <functional>
 #include <boost/concept/assert.hpp>
 #include <boost/icl/concept/interval.hpp>
+#include <boost/icl/detail/concept_check.hpp>
 #include <boost/icl/type_traits/succ_pred.hpp>
 #include <boost/icl/type_traits/value_size.hpp>
 #include <boost/icl/type_traits/type_to_string.hpp>


### PR DESCRIPTION
Without this `#include` if you just do

    #include <boost/icl/right_open_interval.hpp>

you'll get a load of errors about `BOOST_CONCEPT_ASSERT` not being an expression, and various other things. This fixes that.