### PR TITLE
Feature/remove less than comparable constraint

### DIFF
--- a/include/boost/icl/closed_interval.hpp
+++ b/include/boost/icl/closed_interval.hpp
@@ -34,7 +34,7 @@ public:
         : _lwb(unit_element<DomainT>::value()), _upb(identity_element<DomainT>::value()) 
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        //////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
     }
 
@@ -45,7 +45,7 @@ public:
         : _lwb(val), _upb(val)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        //////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_STATIC_ASSERT((!icl::is_continuous<DomainT>::value));
     }
 
@@ -54,7 +54,7 @@ public:
         _lwb(low), _upb(up)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        //////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
     DomainT lower()const{ return _lwb; }

--- a/include/boost/icl/concept/interval.hpp
+++ b/include/boost/icl/concept/interval.hpp
@@ -33,6 +33,14 @@ Copyright (c) 2010-2010: Joachim Faulhaber
 namespace boost{namespace icl
 {
 
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+lower_less_equal(const Type& left, const Type& right);
+
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+upper_less_equal(const Type& left, const Type& right);
+
 //==============================================================================
 //= Ordering
 //==============================================================================

--- a/include/boost/icl/concept/interval.hpp
+++ b/include/boost/icl/concept/interval.hpp
@@ -33,14 +33,6 @@ Copyright (c) 2010-2010: Joachim Faulhaber
 namespace boost{namespace icl
 {
 
-template<class Type>
-typename boost::enable_if<is_interval<Type>, bool>::type
-lower_less_equal(const Type& left, const Type& right);
-
-template<class Type>
-typename boost::enable_if<is_interval<Type>, bool>::type
-upper_less_equal(const Type& left, const Type& right);
-
 //==============================================================================
 //= Ordering
 //==============================================================================
@@ -586,113 +578,6 @@ is_empty(const Type& object)
 }
 
 //==============================================================================
-//= Orderings, containedness (non empty)
-//==============================================================================
-namespace non_empty
-{
-
-    template<class Type>
-    inline typename boost::enable_if<is_asymmetric_interval<Type>, bool>::type
-    exclusive_less(const Type& left, const Type& right)
-    {
-        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
-        return domain_less_equal<Type>(upper(left), lower(right));
-    }
-
-    template<class Type>
-    inline typename boost::enable_if<is_discrete_interval<Type>, bool>::type
-    exclusive_less(const Type& left, const Type& right)
-    {
-        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
-        return domain_less<Type>(last(left), first(right));
-    }
-
-    template<class Type>
-    inline typename boost::
-    enable_if<has_symmetric_bounds<Type>, bool>::type
-    exclusive_less(const Type& left, const Type& right)
-    {
-        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
-        return domain_less<Type>(last(left), first(right));
-    }
-
-    template<class Type>
-    inline typename boost::enable_if<is_continuous_interval<Type>, bool>::type
-    exclusive_less(const Type& left, const Type& right)
-    {
-        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
-        return     domain_less <Type>(upper(left), lower(right))
-            || (   domain_equal<Type>(upper(left), lower(right))
-                && inner_bounds(left,right) != interval_bounds::open() );
-    }
-
-    template<class Type>
-    inline typename boost::enable_if<is_interval<Type>, bool>::type
-    contains(const Type& super, const Type& sub)
-    {
-        return lower_less_equal(super,sub) && upper_less_equal(sub,super);
-    }
-
-
-} //namespace non_empty
-
-
-//- contains -------------------------------------------------------------------
-template<class Type>
-inline typename boost::enable_if<is_interval<Type>, bool>::type
-contains(const Type& super, const Type& sub)
-{
-    return icl::is_empty(sub) || non_empty::contains(super, sub);
-}
-
-template<class Type>
-typename boost::enable_if<is_discrete_static<Type>, bool>::type
-contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
-{
-    return domain_less_equal<Type>(icl::first(super), element                  )
-        && domain_less_equal<Type>(                   element, icl::last(super));
-}
-
-template<class Type>
-typename boost::enable_if<is_continuous_left_open<Type>, bool>::type
-contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
-{
-    return domain_less      <Type>(icl::lower(super), element                   )
-        && domain_less_equal<Type>(                   element, icl::upper(super));
-}
-
-template<class Type>
-typename boost::enable_if<is_continuous_right_open<Type>, bool>::type
-contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
-{
-    return domain_less_equal<Type>(icl::lower(super), element                   )
-        && domain_less      <Type>(                   element, icl::upper(super));
-}
-
-template<class Type>
-typename boost::enable_if<has_dynamic_bounds<Type>, bool>::type
-contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
-{
-    return
-        (is_left_closed(super.bounds())
-            ? domain_less_equal<Type>(lower(super), element)
-            :       domain_less<Type>(lower(super), element))
-    &&
-        (is_right_closed(super.bounds())
-            ? domain_less_equal<Type>(element, upper(super))
-            :       domain_less<Type>(element, upper(super)));
-}
-
-//- within ---------------------------------------------------------------------
-template<class Type>
-inline typename boost::enable_if<is_interval<Type>, bool>::type
-within(const Type& sub, const Type& super)
-{
-    return contains(super,sub);
-}
-
-
-//==============================================================================
 //= Equivalences and Orderings
 //==============================================================================
 //- exclusive_less -------------------------------------------------------------
@@ -898,6 +783,109 @@ upper_less_equal(const Type& left, const Type& right)
     return upper_less(left,right) || upper_equal(left,right);
 }
 
+//==============================================================================
+//= Orderings, containedness (non empty)
+//==============================================================================
+namespace non_empty
+{
+
+    template<class Type>
+    inline typename boost::enable_if<is_asymmetric_interval<Type>, bool>::type
+    exclusive_less(const Type& left, const Type& right)
+    {
+        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
+        return domain_less_equal<Type>(upper(left), lower(right));
+    }
+
+    template<class Type>
+    inline typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+    exclusive_less(const Type& left, const Type& right)
+    {
+        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
+        return domain_less<Type>(last(left), first(right));
+    }
+
+    template<class Type>
+    inline typename boost::
+    enable_if<has_symmetric_bounds<Type>, bool>::type
+    exclusive_less(const Type& left, const Type& right)
+    {
+        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
+        return domain_less<Type>(last(left), first(right));
+    }
+
+    template<class Type>
+    inline typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+    exclusive_less(const Type& left, const Type& right)
+    {
+        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
+        return     domain_less <Type>(upper(left), lower(right))
+            || (   domain_equal<Type>(upper(left), lower(right))
+                && inner_bounds(left,right) != interval_bounds::open() );
+    }
+
+    template<class Type>
+    inline typename boost::enable_if<is_interval<Type>, bool>::type
+    contains(const Type& super, const Type& sub)
+    {
+        return lower_less_equal(super,sub) && upper_less_equal(sub,super);
+    }
+
+} //namespace non_empty
+
+//- contains -------------------------------------------------------------------
+template<class Type>
+inline typename boost::enable_if<is_interval<Type>, bool>::type
+contains(const Type& super, const Type& sub)
+{
+    return icl::is_empty(sub) || non_empty::contains(super, sub);
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_static<Type>, bool>::type
+contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
+{
+    return domain_less_equal<Type>(icl::first(super), element                  )
+        && domain_less_equal<Type>(                   element, icl::last(super));
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_left_open<Type>, bool>::type
+contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
+{
+    return domain_less      <Type>(icl::lower(super), element                   )
+        && domain_less_equal<Type>(                   element, icl::upper(super));
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_right_open<Type>, bool>::type
+contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
+{
+    return domain_less_equal<Type>(icl::lower(super), element                   )
+        && domain_less      <Type>(                   element, icl::upper(super));
+}
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, bool>::type
+contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
+{
+    return
+        (is_left_closed(super.bounds())
+            ? domain_less_equal<Type>(lower(super), element)
+            :       domain_less<Type>(lower(super), element))
+    &&
+        (is_right_closed(super.bounds())
+            ? domain_less_equal<Type>(element, upper(super))
+            :       domain_less<Type>(element, upper(super)));
+}
+
+//- within ---------------------------------------------------------------------
+template<class Type>
+inline typename boost::enable_if<is_interval<Type>, bool>::type
+within(const Type& sub, const Type& super)
+{
+    return contains(super,sub);
+}
 
 //- operator == ----------------------------------------------------------------
 template<class Type>

--- a/include/boost/icl/continuous_interval.hpp
+++ b/include/boost/icl/continuous_interval.hpp
@@ -43,7 +43,7 @@ public:
         , _bounds(interval_bounds::right_open())
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        //////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_STATIC_ASSERT((icl::is_continuous<DomainT>::value)); 
     }
 
@@ -54,7 +54,7 @@ public:
         : _lwb(val), _upb(val), _bounds(interval_bounds::closed())
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        //////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_STATIC_ASSERT((icl::is_continuous<DomainT>::value));
     }
 
@@ -65,7 +65,7 @@ public:
         : _lwb(low), _upb(up), _bounds(bounds)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        //////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_STATIC_ASSERT((icl::is_continuous<DomainT>::value));
     }
 

--- a/include/boost/icl/discrete_interval.hpp
+++ b/include/boost/icl/discrete_interval.hpp
@@ -43,7 +43,7 @@ public:
         , _bounds(interval_bounds::right_open())
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
     }
 
@@ -54,7 +54,7 @@ public:
         : _lwb(val), _upb(val), _bounds(interval_bounds::closed())
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
     }
 
@@ -65,7 +65,7 @@ public:
         : _lwb(low), _upb(up), _bounds(bounds)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
     }
 

--- a/include/boost/icl/interval_base_map.hpp
+++ b/include/boost/icl/interval_base_map.hpp
@@ -201,7 +201,7 @@ public:
     interval_base_map()
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
         BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
     }
@@ -210,7 +210,7 @@ public:
     interval_base_map(const interval_base_map& src): _map(src._map)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
         BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
     }
@@ -224,7 +224,7 @@ public:
     interval_base_map(interval_base_map&& src): _map(boost::move(src._map))
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
         BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
     }

--- a/include/boost/icl/interval_base_set.hpp
+++ b/include/boost/icl/interval_base_set.hpp
@@ -165,7 +165,7 @@ public:
     interval_base_set(const interval_base_set& src): _set(src._set)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
 #   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
@@ -177,7 +177,7 @@ public:
     interval_base_set(interval_base_set&& src): _set(boost::move(src._set))
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
     /** Move assignment operator */

--- a/include/boost/icl/left_open_interval.hpp
+++ b/include/boost/icl/left_open_interval.hpp
@@ -35,7 +35,7 @@ public:
         : _lwb(identity_element<DomainT>::value()), _upb(identity_element<DomainT>::value()) 
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
     //NOTE: Compiler generated copy constructor is used
@@ -45,7 +45,7 @@ public:
         : _lwb(predecessor<DomainT,domain_compare>::apply(val)), _upb(val)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         // Only for discrete types this ctor creates an interval containing 
         // a single element only.
         BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
@@ -58,7 +58,7 @@ public:
         _lwb(low), _upb(up)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
     DomainT lower()const{ return _lwb; }

--- a/include/boost/icl/map.hpp
+++ b/include/boost/icl/map.hpp
@@ -161,7 +161,7 @@ public:
     map()
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
         BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
     }
@@ -181,7 +181,7 @@ public:
         : base_type(src)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
         BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
     }
@@ -200,7 +200,7 @@ public:
         : base_type(boost::move(src))
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
         BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
     }

--- a/include/boost/icl/open_interval.hpp
+++ b/include/boost/icl/open_interval.hpp
@@ -36,7 +36,7 @@ public:
         : _lwb(identity_element<DomainT>::value()), _upb(identity_element<DomainT>::value()) 
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
     //NOTE: Compiler generated copy constructor is used
@@ -46,7 +46,7 @@ public:
         : _lwb(pred(val)), _upb(succ(val))
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         // Only for discrete types this ctor creates an interval containing 
         // a single element only.
         BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
@@ -59,7 +59,7 @@ public:
         _lwb(low), _upb(up)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
     DomainT lower()const{ return _lwb; }

--- a/include/boost/icl/right_open_interval.hpp
+++ b/include/boost/icl/right_open_interval.hpp
@@ -36,7 +36,7 @@ public:
         : _lwb(identity_element<DomainT>::value()), _upb(identity_element<DomainT>::value()) 
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
     //NOTE: Compiler generated copy constructor is used
@@ -46,7 +46,7 @@ public:
         : _lwb(val), _upb(icl::successor<DomainT,domain_compare>::apply(val))
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
         // Only for discrete types this ctor creates an interval containing 
         // a single element only.
         BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
@@ -57,7 +57,7 @@ public:
         _lwb(low), _upb(up)
     {
         BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
-        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        ////BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
     }
 
     domain_type lower()const{ return _lwb; }


### PR DESCRIPTION
Commented out LessThanComparable constraints. This allows specializations for types which do not implement operator < to work.