### PR TITLE
Add missing include

### DIFF
--- a/include/boost/icl/concept/interval.hpp
+++ b/include/boost/icl/concept/interval.hpp
@@ -29,6 +29,7 @@ Copyright (c) 2010-2010: Joachim Faulhaber
 #include <boost/icl/interval_traits.hpp>
 #include <boost/icl/dynamic_interval_traits.hpp>
 
+#include <algorithm>
 
 namespace boost{namespace icl
 {


### PR DESCRIPTION
For std::min, std::max

Since Visual Studio 2019 16.4.0