### PR TITLE
fix unused typedef in release mode

### DIFF
--- a/include/boost/icl/concept/interval.hpp
+++ b/include/boost/icl/concept/interval.hpp
@@ -9,6 +9,7 @@ Copyright (c) 2010-2010: Joachim Faulhaber
 #define BOOST_ICL_CONCEPT_INTERVAL_HPP_JOFA_100323
 
 #include <boost/assert.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/or.hpp>
@@ -112,6 +113,7 @@ singleton(const typename interval_traits<Type>::domain_type& value)
     typedef typename interval_traits<Type>::domain_compare domain_compare;
     BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                  ::is_less_than(value) ));
+    boost::ignore_unused<domain_type, domain_compare>();
 
     return interval_traits<Type>::construct(domain_prior<Type>(value), value);
 }
@@ -125,6 +127,7 @@ singleton(const typename interval_traits<Type>::domain_type& value)
     typedef typename interval_traits<Type>::domain_compare domain_compare;
     BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                  ::is_less_than(value)));
+    boost::ignore_unused<domain_type, domain_compare>();
 
     return interval_traits<Type>::construct( domain_prior<Type>(value)
                                            , domain_next<Type>(value));
@@ -181,6 +184,7 @@ unit_trail(const typename interval_traits<Type>::domain_type& value)
     typedef typename interval_traits<Type>::domain_compare domain_compare;
     BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                  ::is_less_than(value) ));
+    boost::ignore_unused<domain_type, domain_compare>();
 
     return interval_traits<Type>::construct(domain_prior<Type>(value), value);
 }
@@ -198,6 +202,7 @@ unit_trail(const typename interval_traits<Type>::domain_type& value)
     typedef typename interval_traits<Type>::domain_compare domain_compare;
     BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                  ::is_less_than(value)));
+    boost::ignore_unused<domain_type, domain_compare>();
 
     return interval_traits<Type>::construct( domain_prior<Type>(value)
                                            ,  domain_next<Type>(value));
@@ -292,6 +297,8 @@ hull(const typename interval_traits<Type>::domain_type& left,
 {
     typedef typename interval_traits<Type>::domain_type    domain_type;
     typedef typename interval_traits<Type>::domain_compare domain_compare;
+    boost::ignore_unused<domain_type>();
+
     if(domain_compare()(left,right))
     {
         BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
@@ -325,6 +332,8 @@ hull(const typename interval_traits<Type>::domain_type& left,
 {
     typedef typename interval_traits<Type>::domain_type    domain_type;
     typedef typename interval_traits<Type>::domain_compare domain_compare;
+    boost::ignore_unused<domain_type>();
+
     if(domain_compare()(left,right))
     {
         BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
@@ -425,6 +434,8 @@ last(const Type& object)
     typedef typename interval_traits<Type>::domain_compare domain_compare;
     BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                  ::is_less_than(upper(object)) ));
+    boost::ignore_unused<domain_type, domain_compare>();
+
     return domain_prior<Type>(upper(object));
 }
 
@@ -437,6 +448,8 @@ last(const Type& object)
     typedef typename interval_traits<Type>::domain_compare domain_compare;
     BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                  ::is_less_than_or(upper(object), is_right_closed(object.bounds())) ));
+    boost::ignore_unused<domain_type, domain_compare>();
+
     return is_right_closed(object.bounds()) ?
                                   upper(object) :
                domain_prior<Type>(upper(object));


### PR DESCRIPTION
fix unused typedef in release mode

fix this error in release build
```cpp
In file included from ./include/boost/icl/continuous_interval.hpp:15:
./include/boost/icl/concept/interval.hpp:112:60: error: unused typedef 'domain_compare' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_compare domain_compare;
                                                           ^
./include/boost/icl/concept/interval.hpp:111:60: error: unused typedef 'domain_type' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_type    domain_type;
                                                           ^
./include/boost/icl/concept/interval.hpp:125:60: error: unused typedef 'domain_compare' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_compare domain_compare;
                                                           ^
./include/boost/icl/concept/interval.hpp:124:60: error: unused typedef 'domain_type' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_type    domain_type;
                                                           ^
./include/boost/icl/concept/interval.hpp:181:60: error: unused typedef 'domain_compare' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_compare domain_compare;
                                                           ^
./include/boost/icl/concept/interval.hpp:180:60: error: unused typedef 'domain_type' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_type    domain_type;
                                                           ^
./include/boost/icl/concept/interval.hpp:198:60: error: unused typedef 'domain_compare' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_compare domain_compare;
                                                           ^
./include/boost/icl/concept/interval.hpp:197:60: error: unused typedef 'domain_type' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_type    domain_type;
                                                           ^
./include/boost/icl/concept/interval.hpp:293:60: error: unused typedef 'domain_type' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_type    domain_type;
                                                           ^
./include/boost/icl/concept/interval.hpp:326:60: error: unused typedef 'domain_type' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_type    domain_type;
                                                           ^
./include/boost/icl/concept/interval.hpp:424:60: error: unused typedef 'domain_type' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_type    domain_type;
                                                           ^
./include/boost/icl/concept/interval.hpp:425:60: error: unused typedef 'domain_compare' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_compare domain_compare;
                                                           ^
./include/boost/icl/concept/interval.hpp:436:60: error: unused typedef 'domain_type' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_type    domain_type;
                                                           ^
./include/boost/icl/concept/interval.hpp:437:60: error: unused typedef 'domain_compare' [-Werror,-Wunused-local-typedef]
    typedef typename interval_traits<Type>::domain_compare domain_compare;
                                                           ^
14 errors generated.
```