### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(boost_icl
     Boost::mpl
     Boost::range
     Boost::rational
-    Boost::static_assert
     Boost::type_traits
     Boost::utility
 )

--- a/build.jam
+++ b/build.jam
@@ -18,7 +18,6 @@ constant boost_dependencies :
     /boost/mpl//boost_mpl
     /boost/range//boost_range
     /boost/rational//boost_rational
-    /boost/static_assert//boost_static_assert
     /boost/type_traits//boost_type_traits
     /boost/utility//boost_utility ;
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.