### PR TITLE
Fix unsound numeric_minimum bounds and add symmetric numeric_maximum

### DIFF
--- a/include/boost/icl/concept/interval.hpp
+++ b/include/boost/icl/concept/interval.hpp
@@ -96,6 +96,12 @@ typename enable_if
 singleton(const typename interval_traits<Type>::domain_type& value)
 {
     //ASSERT: This always creates an interval with exactly one element
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_greater_than(value) ));
+    boost::ignore_unused<domain_type, domain_compare>();
+
     return interval_traits<Type>::construct(value, domain_next<Type>(value));
 }
 
@@ -127,6 +133,8 @@ singleton(const typename interval_traits<Type>::domain_type& value)
     typedef typename interval_traits<Type>::domain_compare domain_compare;
     BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                  ::is_less_than(value)));
+    BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_greater_than(value)));
     boost::ignore_unused<domain_type, domain_compare>();
 
     return interval_traits<Type>::construct( domain_prior<Type>(value)
@@ -168,6 +176,12 @@ typename enable_if
 >::type
 unit_trail(const typename interval_traits<Type>::domain_type& value)
 {
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_greater_than(value) ));
+    boost::ignore_unused<domain_type, domain_compare>();
+
     return interval_traits<Type>::construct(value, domain_next<Type>(value));
 }
 
@@ -202,6 +216,8 @@ unit_trail(const typename interval_traits<Type>::domain_type& value)
     typedef typename interval_traits<Type>::domain_compare domain_compare;
     BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                  ::is_less_than(value)));
+    BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_greater_than(value)));
     boost::ignore_unused<domain_type, domain_compare>();
 
     return interval_traits<Type>::construct( domain_prior<Type>(value)
@@ -283,11 +299,21 @@ typename enable_if<is_static_right_open<Type>, Type>::type
 hull(const typename interval_traits<Type>::domain_type& left,
      const typename interval_traits<Type>::domain_type& right)
 {
+    typedef typename interval_traits<Type>::domain_type    domain_type;
     typedef typename interval_traits<Type>::domain_compare domain_compare;
+    boost::ignore_unused<domain_type>();
     if(domain_compare()(left,right))
+    {
+        BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                     ::is_greater_than(right) ));
         return construct<Type>(left, domain_next<Type>(right));
+    }
     else
+    {
+        BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                     ::is_greater_than(left) ));
         return construct<Type>(right, domain_next<Type>(left));
+    }
 }
 
 template<class Type>
@@ -338,6 +364,8 @@ hull(const typename interval_traits<Type>::domain_type& left,
     {
         BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                      ::is_less_than(left) ));
+        BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                     ::is_greater_than(right) ));
         return construct<Type>( domain_prior<Type>(left)
                               ,  domain_next<Type>(right));
     }
@@ -345,6 +373,8 @@ hull(const typename interval_traits<Type>::domain_type& left,
     {
         BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
                                      ::is_less_than(right) ));
+        BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                     ::is_greater_than(left) ));
         return construct<Type>( domain_prior<Type>(right)
                               ,  domain_next<Type>(left));
     }
@@ -400,6 +430,12 @@ enable_if< mpl::and_< mpl::or_<is_static_left_open<Type>, is_static_open<Type> >
          , typename interval_traits<Type>::domain_type>::type
 first(const Type& object)
 {
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_greater_than(lower(object)) ));
+    boost::ignore_unused<domain_type, domain_compare>();
+
     return domain_next<Type>(lower(object));
 }
 
@@ -408,6 +444,12 @@ inline typename enable_if<is_discrete_interval<Type>,
                           typename interval_traits<Type>::domain_type>::type
 first(const Type& object)
 {
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_maximum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_greater_than_or(lower(object), is_left_closed(object.bounds())) ));
+    boost::ignore_unused<domain_type, domain_compare>();
+
     return is_left_closed(object.bounds()) ?
                                  lower(object) :
                domain_next<Type>(lower(object));

--- a/include/boost/icl/type_traits/is_numeric.hpp
+++ b/include/boost/icl/type_traits/is_numeric.hpp
@@ -54,6 +54,36 @@ struct is_numeric<std::complex<Type> >
 };
 
 //--------------------------------------------------------------------------
+// The lowest and highest representable values of a numeric domain. Used by
+// the bound-guards below to detect under-/overflow of domain_prior/domain_next.
+//
+// Note that for non-integral types std::numeric_limits<T>::min() is the smallest
+// *positive* normalized value, NOT the most negative one. The most negative
+// value is lowest(). For integral types lowest()==min(), so lowest()
+// is the correct universal choice for the lower extreme.
+//
+// Types for which is_numeric is true but std::numeric_limits is not specialized
+// (e.g. boost::rational) have no usable bounds, so the guards impose no
+// constraint (return true) rather than comparing against a bogus lowest()/max()
+// that silently default-constructs to T(). If boost::rational ever gets a
+// specialization it will be used automatically.
+//--------------------------------------------------------------------------
+namespace detail
+{
+    // Evaluate the bound comparison compare(left, right), but only when
+    // std::numeric_limits<Type> is specialized. Otherwise the domain has no
+    // usable bounds and the guard imposes no constraint by returning true.
+    // Centralizes the is_specialized check shared by all four guards below.
+    template<class Type, class Compare>
+    inline bool numeric_bound_check(Type left, Type right, Compare compare)
+    {
+        return std::numeric_limits<Type>::is_specialized
+             ? compare(left, right)
+             : true;
+    }
+} // namespace detail
+
+// checks if a value is at/below the lowest representable bound
 template<class Type, class Compare, bool Enable = false>
 struct numeric_minimum
 {
@@ -61,24 +91,52 @@ struct numeric_minimum
     static bool is_less_than_or(Type, bool){ return true; }
 };
 
-template<class Type> 
+template<class Type>
 struct numeric_minimum<Type, std::less<Type>, true>
 {
     static bool is_less_than(Type value)
-    { return std::less<Type>()((std::numeric_limits<Type>::min)(), value); }
+    { return detail::numeric_bound_check(std::numeric_limits<Type>::lowest(), value, std::less<Type>()); }
 
     static bool is_less_than_or(Type value, bool cond)
     { return cond || is_less_than(value); }
 };
 
-template<class Type> 
+template<class Type>
 struct numeric_minimum<Type, std::greater<Type>, true>
 {
     static bool is_less_than(Type value)
-    { return std::greater<Type>()((std::numeric_limits<Type>::max)(), value); }
+    { return detail::numeric_bound_check((std::numeric_limits<Type>::max)(), value, std::greater<Type>()); }
 
     static bool is_less_than_or(Type value, bool cond)
     { return cond || is_less_than(value); }
+};
+
+// checks if a value is at/above the highest representable bound
+template<class Type, class Compare, bool Enable = false>
+struct numeric_maximum
+{
+    static bool is_greater_than(Type){ return true; }
+    static bool is_greater_than_or(Type, bool){ return true; }
+};
+
+template<class Type>
+struct numeric_maximum<Type, std::less<Type>, true>
+{
+    static bool is_greater_than(Type value)
+    { return detail::numeric_bound_check(value, (std::numeric_limits<Type>::max)(), std::less<Type>()); }
+
+    static bool is_greater_than_or(Type value, bool cond)
+    { return cond || is_greater_than(value); }
+};
+
+template<class Type>
+struct numeric_maximum<Type, std::greater<Type>, true>
+{
+    static bool is_greater_than(Type value)
+    { return detail::numeric_bound_check(value, std::numeric_limits<Type>::lowest(), std::greater<Type>()); }
+
+    static bool is_greater_than_or(Type value, bool cond)
+    { return cond || is_greater_than(value); }
 };
 
 //--------------------------------------------------------------------------

--- a/test/test_icl_interval_/test_icl_interval.cpp
+++ b/test/test_icl_interval_/test_icl_interval.cpp
@@ -36,6 +36,7 @@ using namespace boost::icl;
 
 #include <boost/icl/discrete_interval.hpp>
 #include <boost/icl/continuous_interval.hpp>
+#include <boost/icl/interval.hpp>
 
 //- sta.asy.{dis|con} ----------------------------------------------------------
 BOOST_AUTO_TEST_CASE_TEMPLATE
@@ -99,6 +100,37 @@ BOOST_AUTO_TEST_CASE_TEMPLATE
 BOOST_AUTO_TEST_CASE_TEMPLATE
 (fastest_itl_left_open_interval_4_bicremental_types, T, discrete_types)
 {        singelizable_interval_4_bicremental_types<left_open_interval<T> >(); }
+
+// first()/last() must be symmetric guards over the open boundary.
+// last() asserts numeric_minimum (domain_prior can't underflow); first() must
+// likewise assert numeric_maximum (domain_next can't overflow). This checks the
+// guards pass on valid intervals and that both first() overloads still return
+// the correct boundary element. See https://github.com/boostorg/icl/issues/58
+BOOST_AUTO_TEST_CASE(test_itl_interval_first_last_symmetry)
+{
+    // Static interval types -> first()/last() overloads gated on is_static_*.
+    BOOST_CHECK_EQUAL(icl::first(right_open_interval<int>(2,7)), 2); // [2,7)
+    BOOST_CHECK_EQUAL(icl::first(left_open_interval <int>(2,7)), 3); // (2,7]
+    BOOST_CHECK_EQUAL(icl::first(open_interval      <int>(2,7)), 3); // (2,7)
+    BOOST_CHECK_EQUAL(icl::first(closed_interval    <int>(2,7)), 2); // [2,7]
+
+    BOOST_CHECK_EQUAL(icl::last (right_open_interval<int>(2,7)), 6); // [2,7)
+    BOOST_CHECK_EQUAL(icl::last (left_open_interval <int>(2,7)), 7); // (2,7]
+    BOOST_CHECK_EQUAL(icl::last (open_interval      <int>(2,7)), 6); // (2,7)
+    BOOST_CHECK_EQUAL(icl::last (closed_interval    <int>(2,7)), 7); // [2,7]
+
+    // Dynamic bounds -> the is_discrete_interval first()/last() overloads,
+    // exercising both branches of the is_left_closed/is_right_closed guards.
+    BOOST_CHECK_EQUAL(icl::first(interval<int>::right_open(2,7)), 2);
+    BOOST_CHECK_EQUAL(icl::first(interval<int>::left_open (2,7)), 3);
+    BOOST_CHECK_EQUAL(icl::first(interval<int>::open      (2,7)), 3);
+    BOOST_CHECK_EQUAL(icl::first(interval<int>::closed    (2,7)), 2);
+
+    BOOST_CHECK_EQUAL(icl::last (interval<int>::right_open(2,7)), 6);
+    BOOST_CHECK_EQUAL(icl::last (interval<int>::left_open (2,7)), 7);
+    BOOST_CHECK_EQUAL(icl::last (interval<int>::open      (2,7)), 6);
+    BOOST_CHECK_EQUAL(icl::last (interval<int>::closed    (2,7)), 7);
+}
 
 //- dyn.dis --------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE_TEMPLATE

--- a/test/test_type_traits_/test_type_traits.cpp
+++ b/test/test_type_traits_/test_type_traits.cpp
@@ -10,6 +10,7 @@ Copyright (c) 2008-2009: Joachim Faulhaber
 #include <disable_test_warnings.hpp>
 #include <limits>
 #include <complex>
+#include <functional>
 #include <string>
 #include <vector>
 #include <set>
@@ -57,6 +58,34 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_is_continuous_type_T, T, continuous_types)
 {
     BOOST_CHECK(is_continuous<T>::value);
     BOOST_CHECK(!is_discrete<T>::value);
+}
+
+// https://github.com/boostorg/icl/issues/58
+// numeric_minimum/numeric_maximum must not consult std::numeric_limits unless
+// it is actually specialized, and must use lowest() (not min()) for the lower
+// extreme so non-integral domains are handled soundly.
+BOOST_AUTO_TEST_CASE(test_numeric_minimum_maximum_bounds)
+{
+    typedef boost::rational<int> Q;
+
+    // Integral: lowest()==min(), behavior preserved.
+    BOOST_CHECK(( numeric_minimum<int, std::less<int>,    is_numeric<int>::value>::is_less_than(-1)));
+    BOOST_CHECK((!numeric_minimum<int, std::less<int>,    is_numeric<int>::value>::is_less_than((std::numeric_limits<int>::min)())));
+    BOOST_CHECK(( numeric_maximum<int, std::less<int>,    is_numeric<int>::value>::is_greater_than(1)));
+    BOOST_CHECK((!numeric_maximum<int, std::less<int>,    is_numeric<int>::value>::is_greater_than((std::numeric_limits<int>::max)())));
+
+    // Floating point: the min()/lowest() trap. A negative value is a valid lower bound.
+    BOOST_CHECK(( numeric_minimum<double, std::less<double>,    is_numeric<double>::value>::is_less_than(-1.0)));
+    BOOST_CHECK((!numeric_minimum<double, std::less<double>,    is_numeric<double>::value>::is_less_than(std::numeric_limits<double>::lowest())));
+    BOOST_CHECK(( numeric_maximum<double, std::greater<double>, is_numeric<double>::value>::is_greater_than(-1.0)));
+    BOOST_CHECK((!numeric_maximum<double, std::greater<double>, is_numeric<double>::value>::is_greater_than(std::numeric_limits<double>::lowest())));
+
+    // boost::rational: is_numeric==true but numeric_limits unspecialized -> impose no constraint.
+    BOOST_CHECK((std::numeric_limits<Q>::is_specialized == false));
+    BOOST_CHECK(( numeric_minimum<Q, std::less<Q>,    is_numeric<Q>::value>::is_less_than(Q(-1,1))));
+    BOOST_CHECK(( numeric_minimum<Q, std::less<Q>,    is_numeric<Q>::value>::is_less_than(Q( 0,1))));
+    BOOST_CHECK(( numeric_maximum<Q, std::less<Q>,    is_numeric<Q>::value>::is_greater_than(Q(-1,1))));
+    BOOST_CHECK(( numeric_maximum<Q, std::greater<Q>, is_numeric<Q>::value>::is_greater_than(Q( 0,1))));
 }
 
 BOOST_AUTO_TEST_CASE(test_is_continuous_type)


### PR DESCRIPTION
numeric_minimum relied solely on is_numeric<T>::value to decide whether to query std::numeric_limits<T>. For types where is_numeric is true but numeric_limits is not specialized (e.g. boost::rational), min()/max() silently fall back to a default-constructed T(), producing wrong bound checks (#58). It also used min() for the lower extreme, which for non-integral types is the smallest *positive* value rather than the most negative one.

Changes:
  - Guard all bound checks on std::numeric_limits<T>::is_specialized; unspecialized numeric domains now impose no constraint instead of comparing against a bogus default-constructed bound.
  - Use lowest() (not min()) for the lower extreme.
  - Add a numeric_maximum trait mirroring numeric_minimum to detect domain_next overflow, and assert it wherever an interval boundary is built via domain_next (singleton, unit_trail, hull) and in first(), making first()/last() symmetric.
  - Add regression tests for the bound traits (int, double, rational) and for first()/last() across all bound flavors.

Fixes #58